### PR TITLE
Fixed --files argument to sort alphabetically

### DIFF
--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -312,7 +312,7 @@ impl<W: Write> Printer<W> {
         Ok(())
     }
 
-    pub fn print_results<'a, I>(&mut self, languages: I, compact: bool) -> io::Result<()>
+    pub fn print_results<'a, I>(&mut self, languages: I, compact: bool, is_sorted: bool) -> io::Result<()>
     where
         I: Iterator<Item = (&'a LanguageType, &'a Language)>,
     {
@@ -337,14 +337,16 @@ impl<W: Write> Printer<W> {
 
                 if self.list_files {
                     self.print_subrow()?;
-
+                    let mut reports: Vec<_> = language.reports.clone();
+                    if !is_sorted {
+                        reports.sort_by(|a, b| a.name.cmp(&b.name));
+                    }
                     if compact {
-                        for report in &language.reports {
+                        for report in &reports {
                             writeln!(self.writer, "{:1$}", report, self.path_length)?;
                         }
                     } else {
-                        let (a, b): (Vec<_>, Vec<_>) = language
-                            .reports
+                        let (a, b): (Vec<_>, Vec<_>) = reports
                             .iter()
                             .partition(|r| r.stats.blobs.is_empty());
                         for reports in &[&a, &b] {

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -312,7 +312,12 @@ impl<W: Write> Printer<W> {
         Ok(())
     }
 
-    pub fn print_results<'a, I>(&mut self, languages: I, compact: bool, is_sorted: bool) -> io::Result<()>
+    pub fn print_results<'a, I>(
+        &mut self,
+        languages: I,
+        compact: bool,
+        is_sorted: bool,
+    ) -> io::Result<()>
     where
         I: Iterator<Item = (&'a LanguageType, &'a Language)>,
     {
@@ -337,7 +342,8 @@ impl<W: Write> Printer<W> {
 
                 if self.list_files {
                     self.print_subrow()?;
-                    let mut reports: Vec<&Report> = language.reports.iter().map(|report| &*report).collect();
+                    let mut reports: Vec<&Report> =
+                        language.reports.iter().map(|report| &*report).collect();
                     if !is_sorted {
                         reports.sort_by(|&a, &b| a.name.cmp(&b.name));
                     }
@@ -346,9 +352,8 @@ impl<W: Write> Printer<W> {
                             writeln!(self.writer, "{:1$}", report, self.path_length)?;
                         }
                     } else {
-                        let (a, b): (Vec<&Report>, Vec<&Report>) = reports
-                            .iter()
-                            .partition(|&r| r.stats.blobs.is_empty());
+                        let (a, b): (Vec<&Report>, Vec<&Report>) =
+                            reports.iter().partition(|&r| r.stats.blobs.is_empty());
                         for reports in &[&a, &b] {
                             let mut first = true;
                             for report in reports.iter() {

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -337,18 +337,18 @@ impl<W: Write> Printer<W> {
 
                 if self.list_files {
                     self.print_subrow()?;
-                    let mut reports: Vec<_> = language.reports.clone();
+                    let mut reports: Vec<&Report> = language.reports.iter().map(|report| &*report).collect();
                     if !is_sorted {
-                        reports.sort_by(|a, b| a.name.cmp(&b.name));
+                        reports.sort_by(|&a, &b| a.name.cmp(&b.name));
                     }
                     if compact {
-                        for report in &reports {
+                        for &report in &reports {
                             writeln!(self.writer, "{:1$}", report, self.path_length)?;
                         }
                     } else {
-                        let (a, b): (Vec<_>, Vec<_>) = reports
+                        let (a, b): (Vec<&Report>, Vec<&Report>) = reports
                             .iter()
-                            .partition(|r| r.stats.blobs.is_empty());
+                            .partition(|&r| r.stats.blobs.is_empty());
                         for reports in &[&a, &b] {
                             let mut first = true;
                             for report in reports.iter() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         Cli::print_supported_languages()?;
         process::exit(0);
     }
-
     let config = cli.override_config(Config::from_config_files());
     let mut languages = Languages::new();
 
@@ -94,13 +93,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     printer.print_header()?;
 
+    let mut is_sorted = false;
     if let Some(sort_category) = cli.sort.or(config.sort) {
         for (_, ref mut language) in &mut languages {
             language.sort_by(sort_category);
         }
 
         let mut languages: Vec<_> = languages.iter().collect();
-
         match sort_category {
             Sort::Blanks => languages.sort_by(|a, b| b.1.blanks.cmp(&a.1.blanks)),
             Sort::Comments => languages.sort_by(|a, b| b.1.comments.cmp(&a.1.comments)),
@@ -108,14 +107,14 @@ fn main() -> Result<(), Box<dyn Error>> {
             Sort::Files => languages.sort_by(|a, b| b.1.reports.len().cmp(&a.1.reports.len())),
             Sort::Lines => languages.sort_by(|a, b| b.1.lines().cmp(&a.1.lines())),
         }
-
+        is_sorted = true;
         if cli.sort_reverse {
-            printer.print_results(languages.into_iter().rev(), cli.compact)?;
+            printer.print_results(languages.into_iter().rev(), cli.compact, is_sorted)?;
         } else {
-            printer.print_results(languages.into_iter(), cli.compact)?;
+            printer.print_results(languages.into_iter(), cli.compact, is_sorted)?;
         }
     } else {
-        printer.print_results(languages.iter(), cli.compact)?;
+        printer.print_results(languages.iter(), cli.compact, is_sorted)?;
     }
 
     printer.print_total(&languages)?;


### PR DESCRIPTION
Now if  ```--files``` argument is found it will sort by default alphabetically the name of the files. If ```--sort``` argument is also provided (for example ```tokei --files --sort blanks```), the sorting for files will be ignored and it will only sort by given argument.
Before:
![image](https://github.com/UPB-CS-OpenSourceUpstream/tokei/assets/119881489/b1e6bb7d-3e6e-4d21-832b-55d97758aa80)

After: 
![image](https://github.com/UPB-CS-OpenSourceUpstream/tokei/assets/119881489/a71a572e-4068-423c-b8bb-8bd004fea5a2)


Should fix  #1053
